### PR TITLE
fix(protocol-http): remove beforeunload handler

### DIFF
--- a/packages/plugin-protocol-http/src/http.ts
+++ b/packages/plugin-protocol-http/src/http.ts
@@ -47,13 +47,6 @@ declare module '@tinkoff/request-core/lib/types.h' {
 }
 
 const isBrowser = typeof window !== 'undefined';
-let isPageUnloaded = false;
-
-if (isBrowser) {
-    window.addEventListener('beforeunload', () => {
-        isPageUnloaded = true;
-    });
-}
 
 /**
  * Makes http/https request.
@@ -251,7 +244,7 @@ export default ({
                     });
                 })
                 .catch((err) => {
-                    if (ended || (err && isPageUnloaded)) {
+                    if (ended) {
                         return;
                     }
 


### PR DESCRIPTION
This actually might be considered a breaking change as it will reveal abort errors when a page is getting unloaded and these errors should be handled properly on called side now.

It mostly affects only firefox browser and it has a long-standing [issue](https://bugzilla.mozilla.org/show_bug.cgi?id=1280189). I haven't found a way to resolve it properly:
- pagehide event doesn't help as it is called after request is got aborted and any handler for errors will be executed before the next page load
- currently, the error thrown by firefox is a network generous error without any details that request is aborted due to page unload

